### PR TITLE
let it work if freetype is compiled with FT_CONFIG_OPTION_ERROR_STRINGS

### DIFF
--- a/freetype.lua
+++ b/freetype.lua
@@ -103,10 +103,14 @@ local Error_Names = {
 	[0xBA] = 'Corrupted Font Glyphs',
 }
 
+local has_error_strings = pcall(function () return C.FT_Error_String end)
 local function checkz(result)
 	if result == 0 then return end
+	local estr
+	if has_error_strings then estr = C.FT_Error_String(result) end
+	estr = estr~=nil and ffi.string(estr) or nil
 	error(string.format('freetype error %d: %s', result,
-		Error_Names[result] or '<unknown error>'), 2)
+		estr or Error_Names[result] or '<unknown error>'), 2)
 end
 
 local function nonzero(ret)


### PR DESCRIPTION

 If freetype is compiled with FT_CONFIG_OPTION_ERROR_STRINGS you can call FT_Error_String to get error string (this will be stable even if they change error codes)
If it is not compiled with FT_CONFIG_OPTION_ERROR_STRINGS it should work as before.